### PR TITLE
TSLint issues

### DIFF
--- a/src/api/BBUserInfo.ts
+++ b/src/api/BBUserInfo.ts
@@ -41,7 +41,7 @@ export abstract class BBUserInfo {
 
     public getUserInfo(): Promise<BBBackend.IUserInfo> {
         return new Promise((resolve, reject) => {
-            let parameters;
+            let parameters: BBBackend.UserParameter;
 
             if (this.userInfo) {
                 resolve(this.userInfo);
@@ -49,21 +49,17 @@ export abstract class BBUserInfo {
             }
 
             if (this._userName) {
-                const param: BBBackend.UserParameter = {
+                parameters = {
                     userName: this._userName
                 };
-                parameters = param;
             } else if (this._userId) {
-                const param: BBBackend.UserParameter = {
+                parameters = {
                     userId: this._userId
                 };
-                parameters = param;
             } else {
                 throw new Error (
-                  "BBUserInfo: expecting userId or userName to be not null. Rejecting getUserInfo().."
+                  "BBUserInfo: expecting userId or userName to be not null."
                 );
-                reject();
-                return;
             }
 
             Backend.getBackend().getUserInfo(parameters).then((information) => {

--- a/src/backend/BBNativeBackend.ts
+++ b/src/backend/BBNativeBackend.ts
@@ -8,7 +8,7 @@ export default class BBNativeBackend extends BBBackend {
     /* COURSES */
     public getEnrolledCourses(parameters: BBBackend.EnrolledCoursesParameter): Promise<BBBackend.ICourseID[]> {
         const path = "/learn/api/public/v1/users/" + parameters.userId + "/courses?offset=" + parameters.offset;
-        console.log(path)
+        console.log(path);
         return new Promise((resolve, reject) => {
             HTTPRequest.getAsync(path).then((response) => {
                 const allCourseInformation = JSON.parse(response);
@@ -34,9 +34,9 @@ export default class BBNativeBackend extends BBBackend {
                 const courseInformation = JSON.parse(response);
 
                 const resultObject: BBBackend.ICourseInformation = {
+                    description: courseInformation.description,
                     id: courseInformation.courseId,
-                    name: courseInformation.name,
-                    description: courseInformation.description
+                    name: courseInformation.name
                 };
 
                 resolve(resultObject);
@@ -63,12 +63,12 @@ export default class BBNativeBackend extends BBBackend {
                   const userJson = JSON.parse(response);
 
                   const userObject: BBBackend.IUserInfo = {
-                      id: userJson.id,
-                      username: userJson.userName,
+                      email: userJson.contact.email,
                       firstname: userJson.name.given,
-                      surname: userJson.name.family,
+                      id: userJson.id,
                       student: userJson.studentId,
-                      email: userJson.contact.email
+                      surname: userJson.name.family,
+                      username: userJson.userName
                   };
 
                   resolve(userObject);
@@ -86,12 +86,12 @@ export default class BBNativeBackend extends BBBackend {
                     }
 
                     const userObject: BBBackend.IUserInfo = {
-                        id: userJson.results[0].id,
-                        username: userJson.results[0].userName,
+                        email: userJson.results[0].contact.email,
                         firstname: userJson.results[0].name.given,
-                        surname: userJson.results[0].name.family,
+                        id: userJson.results[0].id,
                         student: userJson.results[0].studentId,
-                        email: userJson.results[0].contact.email
+                        surname: userJson.results[0].name.family,
+                        username: userJson.results[0].userName
                     };
 
                     resolve(userObject);

--- a/src/common/BBBackend.ts
+++ b/src/common/BBBackend.ts
@@ -11,7 +11,7 @@ export default abstract class BBBackend {
 
     /**
      * Get courses the user is enrolled.
-     * @param The parameters to use with this function.
+     * @param parameters The parameters to use with this function.
      * @returns A promise with an array of courses the user is enrolled in.
      */
     public abstract getEnrolledCourses(parameters: BBBackend.EnrolledCoursesParameter):

--- a/src/common/WindowConnectionManager.ts
+++ b/src/common/WindowConnectionManager.ts
@@ -8,7 +8,7 @@ export default class WindowConnectionManager {
 
     constructor(_window: Window, backend?: BBBackend) {
         this.window = _window;
-        this.callbackList = new Object();
+        this.callbackList = {};
         this.backend = backend;
 
         const selfRef = this;

--- a/src/common/WindowMessage.ts
+++ b/src/common/WindowMessage.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:max-classes-per-file */
+
 import BBBackend from './BBBackend';
 
 export enum WindowMessageType {
@@ -5,7 +7,6 @@ export enum WindowMessageType {
     RETURN = 2
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class WindowMessageFactory {
     public static fromJson(jsonObject: any) {
         const baseMessage = WindowMessage.fromJsonObject(jsonObject);
@@ -21,7 +22,6 @@ export class WindowMessageFactory {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class WindowMessage {
     private static readonly UUID_ID = "uuid";
     private static readonly TYPE_ID = "type";
@@ -62,7 +62,7 @@ export class WindowMessage {
         });
     }
 }
-// tslint:disable-next-line:max-classes-per-file
+
 export class WindowFunctionCall extends WindowMessage {
     private static readonly METHOD_SIGNATURE_ID = "methodSignature";
     private static readonly PARAMETERS_ID = "parameters";
@@ -102,7 +102,6 @@ export class WindowFunctionCall extends WindowMessage {
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class WindowFunctionReturn extends WindowMessage {
     private static readonly RETURN_VALUE_ID = "returnValue";
 

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
         "interface-over-type-literal": false,
         "quotemark": false,
         "member-ordering": false,
+        "no-console": false,
         "variable-name": [true, "allow-leading-underscore"],
         "trailing-comma": false
     },

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,6 @@
         "interface-over-type-literal": false,
         "quotemark": false,
         "member-ordering": false,
-        "no-console": false,
         "variable-name": [true, "allow-leading-underscore"],
         "trailing-comma": false
     },


### PR DESCRIPTION
In een aantal bestanden waren TSLint issues. Ik heb deze opgelost en
een uitzondering toegevoegd voor "no-console", omdat we nogal op deze
functionaliteit leunen.

Voor BBUserInfo heb ik twee onbereikbare regels code verwijderd en de
Error melding aangepast. Nadat er een Error is gethrowed kan de promise
niet meer afgewezen worden en daardoor klopt de error tekst niet meer.
Mocht dit de bedoeling zijn dan moet de reject() aanroep voor de throw
plaatsvinden. Op dit moment veranderd er dus niet qua gedrag.